### PR TITLE
Fix README entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install -r requirements.txt
 ## 🛠️ Usage
 ▶️ Run the scraper:
 ```bash
-python3 tiktok_scraper.py
+python3 main.py
 ```
 Then choose:
 ```bash


### PR DESCRIPTION
## Summary
- update README usage instructions

## Testing
- `pip install -r requirements.txt`
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_e_68464fc44e5c832cbcecee407de13c5e